### PR TITLE
Write pointer file in binary mode

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1137,7 +1137,7 @@ class Package(models.Model):
             root.find(".//mets:fileGrp", namespaces=utils.NSMAP).set(
                 "USE", "Archival Information Package"
             )
-        with open(pointer_absolute_path, "w") as f:
+        with open(pointer_absolute_path, "wb") as f:
             f.write(
                 etree.tostring(
                     root, pretty_print=True, xml_declaration=True, encoding="utf-8"


### PR DESCRIPTION
The `etree.tostring()` function generates bytes, not a string. Therefore, the file to be written must be opened in binary mode, otherwise this error is thrown.

`TypeError: write() argument must be str, not bytes`

I believe this would have worked with python2. python3 enforces this distinction.

Resolves https://github.com/archivematica/Issues/issues/1545